### PR TITLE
Updates to required packages

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-selfies==1.0.1
+selfies==2.1.0
 peewee>=3.9.3
 numpy>=1.16.3
-crem==0.2.4
-loguru==0.4.1
+crem==0.2.9
+loguru==0.6.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ peewee>=3.9.3
 numpy>=1.16.3
 crem==0.2.9
 loguru==0.6.0
+pandas>=1.0.*

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     name="deriver",
     description="Deriver: for all your molecule generation needs.",
     long_description="A software tool for the generation of novel chemical entities.",
-    version="2.9.0",
+    version="2.9.1",
     url="https://github.com/cyclica/deriver",
     license="All Rights Reserved Cyclica Inc.",
     packages=find_packages("src"),
@@ -13,11 +13,11 @@ setup(
     include_package_data=True,
     zip_safe=False,
     install_requires=[
-        "selfies==1.0.1",
+        "selfies==2.1.0",
         "peewee>=3.9.3",
         "numpy>=1.16.3",
-        "crem==0.2.4",
-        "loguru==0.4.1",
+        "crem==0.2.9",
+        "loguru==0.6.0",
         "pandas>=1.0.*",
     ],
 )

--- a/src/deriver.egg-info/PKG-INFO
+++ b/src/deriver.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.1
 Name: deriver
-Version: 2.9.0
+Version: 2.9.1
 Summary: Deriver: for all your molecule generation needs.
 Home-page: https://github.com/cyclica/deriver
 License: All Rights Reserved Cyclica Inc.

--- a/src/deriver.egg-info/requires.txt
+++ b/src/deriver.egg-info/requires.txt
@@ -1,6 +1,6 @@
-selfies==1.0.1
+selfies==2.1.0
 peewee>=3.9.3
 numpy>=1.16.3
-crem==0.2.4
-loguru==0.4.1
+crem==0.2.9
+loguru==0.6.0
 pandas>=1.0.*


### PR DESCRIPTION
Updated:
+ `selfies` from `1.0.1` to `2.1.0`. **Note**: this version only supports `Python >= 3.7`. If compatibility with previous versions is required, this should be changed to `2.0.0`.
+ `crem` from `0.2.4` to `0.2.9`
+ `loguru` from `0.4.1` to `0.6.0`

Added:
+ `pandas>=1.0.*` to `requirements.txt` to match with `requires.txt`, `setup.py`

Incremented version to `2.9.1`

I did a bit of testing and nothing broke. That said, it'd be great if some more thorough testing was done.